### PR TITLE
Fix: Migrate to Artifact Registry from deprecated Container Registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,14 +6,14 @@ steps:
     args: 
       - 'build'
       - '-t'
-      - 'gcr.io/$PROJECT_ID/reflectica-backend:$COMMIT_SHA'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/reflectica-backend/reflectica-backend:$COMMIT_SHA'
       - '-t'
-      - 'gcr.io/$PROJECT_ID/reflectica-backend:latest'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/reflectica-backend/reflectica-backend:latest'
       - '.'
 
-  # Step 2: Push the image to Google Container Registry
+  # Step 2: Push the image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/reflectica-backend']
+    args: ['push', '--all-tags', 'us-central1-docker.pkg.dev/$PROJECT_ID/reflectica-backend/reflectica-backend']
 
   # Step 3: Deploy to Cloud Run with all configurations
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -22,7 +22,7 @@ steps:
       - 'run'
       - 'deploy'
       - 'reflectica-backend'
-      - '--image=gcr.io/$PROJECT_ID/reflectica-backend:$COMMIT_SHA'
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/reflectica-backend/reflectica-backend:$COMMIT_SHA'
       - '--region=us-central1'
       - '--platform=managed'
       - '--allow-unauthenticated'


### PR DESCRIPTION
## Summary
- Update `cloudbuild.yaml` to use Artifact Registry instead of deprecated Container Registry
- Created new Artifact Registry repository: `reflectica-backend`
- Change all image references from `gcr.io` to `us-central1-docker.pkg.dev` format

## Problem Fixed
Cloud Build was failing with error:
> Container Registry is deprecated and shutting down, please use the auto migration tool to migrate to Artifact Registry

## Changes Made
**Updated all image references in cloudbuild.yaml:**
- Build tags: `gcr.io/PROJECT_ID/reflectica-backend` → `us-central1-docker.pkg.dev/PROJECT_ID/reflectica-backend/reflectica-backend`
- Push target: Updated to match new Artifact Registry format
- Deploy image: Updated Cloud Run deployment to use new image path

## Benefits
- ✅ **Future-proof**: Artifact Registry is the modern replacement for Container Registry
- ✅ **Better performance**: Improved security and performance vs Container Registry
- ✅ **Regional storage**: Images stored in us-central1 for faster deployments

## Test Plan
- [x] Created Artifact Registry repository in GCP
- [ ] Merge PR to trigger automatic deployment
- [ ] Verify Cloud Build succeeds with new registry
- [ ] Confirm Cloud Run deployment works with Artifact Registry images

This fixes the immediate deployment blocker and modernizes our container storage.